### PR TITLE
use convex linter

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,7 @@ import pluginJs from "@eslint/js";
 import tseslint from "typescript-eslint";
 import reactHooks from "eslint-plugin-react-hooks";
 import reactRefresh from "eslint-plugin-react-refresh";
+import convexPlugin from "@convex-dev/eslint-plugin";
 
 export default [
   {
@@ -39,7 +40,12 @@ export default [
     languageOptions: {
       globals: globals.worker,
     },
+    plugins: {
+      "@convex-dev": convexPlugin,
+    },
     rules: {
+      ...convexPlugin.configs.recommended[0].rules,
+
       "@typescript-eslint/no-floating-promises": "error",
       "@typescript-eslint/no-explicit-any": "off",
       "no-unused-vars": "off",

--- a/example/convex/example.ts
+++ b/example/convex/example.ts
@@ -420,7 +420,7 @@ export const recordUploadMetadata = rag.defineOnComplete<DataModel>(
       .unique();
     if (existing) {
       console.debug("replacing file", existing._id, entry);
-      await ctx.db.replace(existing._id, metadata);
+      await ctx.db.replace("fileMetadata", existing._id, metadata);
     } else if (entry.status === "ready") {
       console.debug("inserting file", entry);
       await ctx.db.insert("fileMetadata", metadata);
@@ -446,7 +446,7 @@ async function _deleteFile(ctx: MutationCtx, entryId: EntryId) {
     .withIndex("entryId", (q) => q.eq("entryId", entryId))
     .unique();
   if (file) {
-    await ctx.db.delete(file._id);
+    await ctx.db.delete("fileMetadata", file._id);
     await ctx.storage.delete(file.storageId);
     await rag.deleteAsync(ctx, { entryId });
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "chokidar-cli": "3.0.0",
         "convex": "1.35.1",
         "convex-helpers": "0.1.111",
-        "convex-test": "0.0.41",
+        "convex-test": "0.0.49",
         "eslint": "9.39.2",
         "eslint-plugin-react": "7.37.5",
         "eslint-plugin-react-hooks": "7.0.1",
@@ -4821,13 +4821,13 @@
       }
     },
     "node_modules/convex-test": {
-      "version": "0.0.41",
-      "resolved": "https://registry.npmjs.org/convex-test/-/convex-test-0.0.41.tgz",
-      "integrity": "sha512-GPHeYFOi70n7UtW0eCEQFVhzl/+m8PvbWkDCbKpHLybI1MrScf4sVpGeM0cC2qmtxiduxa2nLPbehPalhh9oyQ==",
+      "version": "0.0.49",
+      "resolved": "https://registry.npmjs.org/convex-test/-/convex-test-0.0.49.tgz",
+      "integrity": "sha512-mBDhwvxUZYtRuEx4a9opk7LI6IghcPOHd99QVPAzMugeYeAukLjkFkkkAU9J53edxxwGWfx1IsoKLzC+DK6ugg==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
-        "convex": "^1.16.4"
+        "convex": "^1.32.0"
       }
     },
     "node_modules/cross-spawn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       "devDependencies": {
         "@ai-sdk/openai": "3.0.26",
         "@arethetypeswrong/cli": "0.18.2",
+        "@convex-dev/eslint-plugin": "^2.0.0",
         "@convex-dev/workpool": "0.3.1",
         "@edge-runtime/vm": "5.0.0",
         "@eslint/eslintrc": "3.3.3",
@@ -575,6 +576,213 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@convex-dev/eslint-plugin": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@convex-dev/eslint-plugin/-/eslint-plugin-2.0.0.tgz",
+      "integrity": "sha512-GxYe0b5RoAb7c7JzcAX3t+UrdT6edQDtSgJ2F9UPECLyQGU0TeTkyGsDXNm3HK+MnWYi8isRlqaqoYTUD0Ko+Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@typescript-eslint/types": "~8.58.0",
+        "@typescript-eslint/utils": "~8.58.0"
+      },
+      "peerDependencies": {
+        "convex": "^1.34.1"
+      }
+    },
+    "node_modules/@convex-dev/eslint-plugin/node_modules/@typescript-eslint/project-service": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
+      "integrity": "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.58.2",
+        "@typescript-eslint/types": "^8.58.2",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@convex-dev/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.2.tgz",
+      "integrity": "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@convex-dev/eslint-plugin/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
+      "integrity": "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@convex-dev/eslint-plugin/node_modules/@typescript-eslint/types": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
+      "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@convex-dev/eslint-plugin/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.2.tgz",
+      "integrity": "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.58.2",
+        "@typescript-eslint/tsconfig-utils": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@convex-dev/eslint-plugin/node_modules/@typescript-eslint/utils": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
+      "integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@convex-dev/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
+      "integrity": "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.2",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@convex-dev/eslint-plugin/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@convex-dev/eslint-plugin/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@convex-dev/eslint-plugin/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@convex-dev/eslint-plugin/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@convex-dev/workpool": {
@@ -10478,9 +10686,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
-      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
   "devDependencies": {
     "@ai-sdk/openai": "3.0.26",
     "@arethetypeswrong/cli": "0.18.2",
+    "@convex-dev/eslint-plugin": "^2.0.0",
     "@convex-dev/workpool": "0.3.1",
     "@edge-runtime/vm": "5.0.0",
     "@eslint/eslintrc": "3.3.3",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "chokidar-cli": "3.0.0",
     "convex": "1.35.1",
     "convex-helpers": "0.1.111",
-    "convex-test": "0.0.41",
+    "convex-test": "0.0.49",
     "eslint": "9.39.2",
     "eslint-plugin-react": "7.37.5",
     "eslint-plugin-react-hooks": "7.0.1",

--- a/src/component/chunks.test.ts
+++ b/src/component/chunks.test.ts
@@ -60,7 +60,8 @@ describe("chunks", () => {
     await setupTestNamespace(t);
 
     // Try to insert chunks for a non-existent entry
-    const nonExistentDocId = "j57c3xc4x6j3c4x6j3c4x6j3c4x6" as Id<"entries">;
+    const nonExistentDocId =
+      "0123456789012345678901234entries" as Id<"entries">;
     const chunks = createTestChunks(2);
 
     await expect(

--- a/src/component/chunks.test.ts
+++ b/src/component/chunks.test.ts
@@ -141,10 +141,10 @@ describe("chunks", () => {
     expect(overwrittenChunk2).toBeDefined();
 
     const content1 = await t.run(async (ctx) =>
-      ctx.db.get(overwrittenChunk1!.contentId),
+      ctx.db.get("content", overwrittenChunk1!.contentId),
     );
     const content2 = await t.run(async (ctx) =>
-      ctx.db.get(overwrittenChunk2!.contentId),
+      ctx.db.get("content", overwrittenChunk2!.contentId),
     );
 
     expect(content1!.text).toBe("Overwritten chunk 1 content");
@@ -279,10 +279,10 @@ describe("chunks", () => {
 
     // Verify chunk content
     const doc1Content0 = await t.run(async (ctx) =>
-      ctx.db.get(doc1ChunksList[0].contentId),
+      ctx.db.get("content", doc1ChunksList[0].contentId),
     );
     const doc2Content0 = await t.run(async (ctx) =>
-      ctx.db.get(doc2ChunksList[0].contentId),
+      ctx.db.get("content", doc2ChunksList[0].contentId),
     );
 
     expect(doc1Content0!.text).toBe("Test chunk content 1");
@@ -319,7 +319,7 @@ describe("chunks", () => {
 
     // Verify content
     const content = await t.run(async (ctx) =>
-      ctx.db.get(singleChunk!.contentId),
+      ctx.db.get("content", singleChunk!.contentId),
     );
     expect(content!.text).toBe("Test chunk content 3");
   });

--- a/src/component/chunks.ts
+++ b/src/component/chunks.ts
@@ -22,13 +22,18 @@ import {
   type QueryCtx,
 } from "./_generated/server.js";
 import { insertEmbedding } from "./embeddings/index.js";
-import { vVectorId, type VectorTableName } from "./embeddings/tables.js";
-import { schema, v } from "./schema.js";
-import { getPreviousEntry, publicEntry } from "./helpers.js";
+import {
+  getVectorTableName,
+  validateVectorDimension,
+  vVectorId,
+  type VectorTableName,
+} from "./embeddings/tables.js";
 import {
   filterFieldsFromNumbers,
   numberedFilterFromNamedFilters,
 } from "./filters.js";
+import { getPreviousEntry, publicEntry } from "./helpers.js";
+import { schema, v } from "./schema.js";
 
 const KB = 1_024;
 const MB = 1_024 * KB;
@@ -79,12 +84,14 @@ export async function insertChunks(
       `Deleting ${existingChunks.length} existing chunks for entry ${entryId} at version ${entry.version}`,
     );
   }
+  const vectorTableName = getVectorTableName(
+    validateVectorDimension(namespace.dimension),
+  );
   // TODO: avoid writing if they're the same
   await Promise.all(
     existingChunks.map(async (c) => {
       if (c.state.kind === "ready") {
-        // eslint-disable-next-line @convex-dev/explicit-table-ids -- embeddingId is a VectorTableId (union of vectors_128..vectors_4096)
-        await ctx.db.delete(c.state.embeddingId);
+        await ctx.db.delete(vectorTableName, c.state.embeddingId);
       }
       await ctx.db.delete("content", c.contentId);
       await ctx.db.delete("chunks", c._id);
@@ -222,24 +229,31 @@ export const replaceChunksPage = mutation({
         entry.importance,
         namedFilters,
       );
-      await ctx.db.patch("chunks", chunk._id, { state: { kind: "ready", embeddingId } });
+      await ctx.db.patch("chunks", chunk._id, {
+        state: { kind: "ready", embeddingId },
+      });
     }
     let dataUsedSoFar = 0;
     let indexToDelete = startOrder;
     let chunksToDeleteEmbeddings: Doc<"chunks">[] = [];
     let chunkToAdd: (Doc<"chunks"> & { state: { kind: "pending" } }) | null =
       null;
+
+    const vectorTableName = getVectorTableName(
+      validateVectorDimension(namespace.dimension),
+    );
     async function handleBatch() {
       await Promise.all(
         chunksToDeleteEmbeddings.map(async (chunk) => {
           assert(chunk.state.kind === "ready");
-          // eslint-disable-next-line @convex-dev/explicit-table-ids -- embeddingId is a VectorTableId (union of vectors_128..vectors_4096)
-          const vector = await ctx.db.get(chunk.state.embeddingId);
+          const vector = await ctx.db.get(
+            vectorTableName,
+            chunk.state.embeddingId,
+          );
           assert(vector, `Vector ${chunk.state.embeddingId} not found`);
           // get and delete both count as bandwidth reads
           dataUsedSoFar += getConvexSize(vector) * 2;
-          // eslint-disable-next-line @convex-dev/explicit-table-ids -- embeddingId is a VectorTableId (union of vectors_128..vectors_4096)
-          await ctx.db.delete(chunk.state.embeddingId);
+          await ctx.db.delete(vectorTableName, chunk.state.embeddingId);
           await ctx.db.patch("chunks", chunk._id, {
             state: {
               kind: "replaced",
@@ -515,19 +529,28 @@ export async function deleteChunksPageHandler(
     .withIndex("entryId_order", (q) =>
       q.eq("entryId", entryId).gte("order", startOrder),
     );
+  let vectorTableName: VectorTableName | undefined;
   let dataUsedSoFar = 0;
   for await (const chunk of chunkStream) {
+    if (!vectorTableName) {
+      const namespace = await ctx.db.get("namespaces", chunk.namespaceId);
+      assert(namespace, "namespace not found");
+      vectorTableName = getVectorTableName(
+        validateVectorDimension(namespace.dimension),
+      );
+    }
     // one for the stream read, one for deleting
     dataUsedSoFar += getConvexSize(chunk) * 2;
     await ctx.db.delete("chunks", chunk._id);
     if (chunk.state.kind === "ready") {
-      // eslint-disable-next-line @convex-dev/explicit-table-ids -- embeddingId is a VectorTableId (union of vectors_128..vectors_4096)
-      const embedding = await ctx.db.get(chunk.state.embeddingId);
+      const embedding = await ctx.db.get(
+        vectorTableName,
+        chunk.state.embeddingId,
+      );
       if (embedding) {
         // get and delete both count as bandwidth reads
         dataUsedSoFar += getConvexSize(embedding) * 2;
-        // eslint-disable-next-line @convex-dev/explicit-table-ids -- embeddingId is a VectorTableId (union of vectors_128..vectors_4096)
-        await ctx.db.delete(chunk.state.embeddingId);
+        await ctx.db.delete(vectorTableName, chunk.state.embeddingId);
       }
     }
     dataUsedSoFar += await estimateContentSize(ctx, chunk.contentId);

--- a/src/component/chunks.ts
+++ b/src/component/chunks.ts
@@ -52,14 +52,14 @@ export async function insertChunks(
   ctx: MutationCtx,
   { entryId, startOrder, chunks }: InsertChunksArgs,
 ) {
-  const entry = await ctx.db.get(entryId);
+  const entry = await ctx.db.get("entries", entryId);
   if (!entry) {
     throw new Error(`Entry ${entryId} not found`);
   }
   await ensureLatestEntryVersion(ctx, entry);
 
   // Get the namespace for filter conversion
-  const namespace = await ctx.db.get(entry.namespaceId);
+  const namespace = await ctx.db.get("namespaces", entry.namespaceId);
   assert(namespace, `Namespace ${entry.namespaceId} not found`);
 
   const previousEntry = await getPreviousEntry(ctx, entry);
@@ -83,10 +83,11 @@ export async function insertChunks(
   await Promise.all(
     existingChunks.map(async (c) => {
       if (c.state.kind === "ready") {
+        // eslint-disable-next-line @convex-dev/explicit-table-ids -- embeddingId is a VectorTableId (union of vectors_128..vectors_4096)
         await ctx.db.delete(c.state.embeddingId);
       }
-      await ctx.db.delete(c.contentId);
-      await ctx.db.delete(c._id);
+      await ctx.db.delete("content", c.contentId);
+      await ctx.db.delete("chunks", c._id);
     }),
   );
   const numberedFilter = numberedFilterFromNamedFilters(
@@ -165,7 +166,7 @@ export const replaceChunksPage = mutation({
   returns: v.object({ status: vStatus, nextStartOrder: v.number() }),
   handler: async (ctx, args) => {
     const { entryId, startOrder } = args;
-    const entryOrNull = await ctx.db.get(entryId);
+    const entryOrNull = await ctx.db.get("entries", entryId);
     if (!entryOrNull) {
       throw new Error(`Entry ${entryId} not found`);
     }
@@ -176,7 +177,7 @@ export const replaceChunksPage = mutation({
     }
 
     // Get the namespace for filter conversion
-    const namespace = await ctx.db.get(entry.namespaceId);
+    const namespace = await ctx.db.get("namespaces", entry.namespaceId);
     assert(namespace, `Namespace ${entry.namespaceId} not found`);
 
     const previousEntry = await getPreviousEntry(ctx, entry);
@@ -221,7 +222,7 @@ export const replaceChunksPage = mutation({
         entry.importance,
         namedFilters,
       );
-      await ctx.db.patch(chunk._id, { state: { kind: "ready", embeddingId } });
+      await ctx.db.patch("chunks", chunk._id, { state: { kind: "ready", embeddingId } });
     }
     let dataUsedSoFar = 0;
     let indexToDelete = startOrder;
@@ -232,12 +233,14 @@ export const replaceChunksPage = mutation({
       await Promise.all(
         chunksToDeleteEmbeddings.map(async (chunk) => {
           assert(chunk.state.kind === "ready");
+          // eslint-disable-next-line @convex-dev/explicit-table-ids -- embeddingId is a VectorTableId (union of vectors_128..vectors_4096)
           const vector = await ctx.db.get(chunk.state.embeddingId);
           assert(vector, `Vector ${chunk.state.embeddingId} not found`);
           // get and delete both count as bandwidth reads
           dataUsedSoFar += estimateEmbeddingSize(vector) * 2;
+          // eslint-disable-next-line @convex-dev/explicit-table-ids -- embeddingId is a VectorTableId (union of vectors_128..vectors_4096)
           await ctx.db.delete(chunk.state.embeddingId);
-          await ctx.db.patch(chunk._id, {
+          await ctx.db.patch("chunks", chunk._id, {
             state: {
               kind: "replaced",
               embeddingId: chunk.state.embeddingId,
@@ -324,7 +327,7 @@ export async function buildRanges(
     await Promise.all(
       Array.from(
         new Set(chunks.filter((c) => c !== null).map((c) => c.entryId)),
-      ).map((id) => ctx.db.get(id)),
+      ).map((id) => ctx.db.get("entries", id)),
     )
   ).filter((d): d is Doc<"entries"> => d !== null);
   const entries = entryDocs.map(publicEntry);
@@ -400,7 +403,7 @@ export async function buildRanges(
     }
     const content = await Promise.all(
       contentIds.map(async (contentId) => {
-        const content = await ctx.db.get(contentId);
+        const content = await ctx.db.get("content", contentId);
         assert(content, `Content ${contentId} not found`);
         return { text: content.text, metadata: content.metadata };
       }),
@@ -462,7 +465,7 @@ export const list = query({
       ...chunks,
       page: await Promise.all(
         chunks.page.map(async (chunk) => {
-          const content = await ctx.db.get(chunk.contentId);
+          const content = await ctx.db.get("content", chunk.contentId);
           assert(content, `Content ${chunk.contentId} not found`);
           return publicChunk(chunk, content);
         }),
@@ -516,17 +519,19 @@ export async function deleteChunksPageHandler(
   for await (const chunk of chunkStream) {
     // one for the stream read, one for deleting
     dataUsedSoFar += estimateChunkSize(chunk) * 2;
-    await ctx.db.delete(chunk._id);
+    await ctx.db.delete("chunks", chunk._id);
     if (chunk.state.kind === "ready") {
+      // eslint-disable-next-line @convex-dev/explicit-table-ids -- embeddingId is a VectorTableId (union of vectors_128..vectors_4096)
       const embedding = await ctx.db.get(chunk.state.embeddingId);
       if (embedding) {
         // get and delete both count as bandwidth reads
         dataUsedSoFar += estimateEmbeddingSize(embedding) * 2;
+        // eslint-disable-next-line @convex-dev/explicit-table-ids -- embeddingId is a VectorTableId (union of vectors_128..vectors_4096)
         await ctx.db.delete(chunk.state.embeddingId);
       }
     }
     dataUsedSoFar += await estimateContentSize(ctx, chunk.contentId);
-    await ctx.db.delete(chunk.contentId);
+    await ctx.db.delete("content", chunk.contentId);
     if (dataUsedSoFar > BANDWIDTH_PER_TRANSACTION_HARD_LIMIT) {
       return { isDone: false, nextStartOrder: chunk.order };
     }
@@ -567,7 +572,7 @@ function estimateChunkSize(chunk: Doc<"chunks">) {
 async function estimateContentSize(ctx: QueryCtx, contentId: Id<"content">) {
   let dataUsedSoFar = 0;
   // TODO: if/when deletions don't count as bandwidth, we can remove this.
-  const content = await ctx.db.get(contentId);
+  const content = await ctx.db.get("content", contentId);
   if (content) {
     dataUsedSoFar += content.text.length;
     dataUsedSoFar += JSON.stringify(

--- a/src/component/chunks.ts
+++ b/src/component/chunks.ts
@@ -2,7 +2,7 @@ import { assert } from "convex-helpers";
 import { paginator } from "convex-helpers/server/pagination";
 import { mergedStream, stream } from "convex-helpers/server/stream";
 import { paginationOptsValidator } from "convex/server";
-import { convexToJson, type Infer } from "convex/values";
+import { getConvexSize, type Infer } from "convex/values";
 import {
   statuses,
   vChunk,
@@ -237,7 +237,7 @@ export const replaceChunksPage = mutation({
           const vector = await ctx.db.get(chunk.state.embeddingId);
           assert(vector, `Vector ${chunk.state.embeddingId} not found`);
           // get and delete both count as bandwidth reads
-          dataUsedSoFar += estimateEmbeddingSize(vector) * 2;
+          dataUsedSoFar += getConvexSize(vector) * 2;
           // eslint-disable-next-line @convex-dev/explicit-table-ids -- embeddingId is a VectorTableId (union of vectors_128..vectors_4096)
           await ctx.db.delete(chunk.state.embeddingId);
           await ctx.db.patch("chunks", chunk._id, {
@@ -258,7 +258,7 @@ export const replaceChunksPage = mutation({
     }
     for await (const chunk of chunkStream) {
       // one for the stream read, one for patching / replacing
-      dataUsedSoFar += estimateChunkSize(chunk) * 2;
+      dataUsedSoFar += getConvexSize(chunk) * 2;
       if (chunk.state.kind !== "pending") {
         dataUsedSoFar += 17 * KB; // embedding conservative estimate
       }
@@ -518,14 +518,14 @@ export async function deleteChunksPageHandler(
   let dataUsedSoFar = 0;
   for await (const chunk of chunkStream) {
     // one for the stream read, one for deleting
-    dataUsedSoFar += estimateChunkSize(chunk) * 2;
+    dataUsedSoFar += getConvexSize(chunk) * 2;
     await ctx.db.delete("chunks", chunk._id);
     if (chunk.state.kind === "ready") {
       // eslint-disable-next-line @convex-dev/explicit-table-ids -- embeddingId is a VectorTableId (union of vectors_128..vectors_4096)
       const embedding = await ctx.db.get(chunk.state.embeddingId);
       if (embedding) {
         // get and delete both count as bandwidth reads
-        dataUsedSoFar += estimateEmbeddingSize(embedding) * 2;
+        dataUsedSoFar += getConvexSize(embedding) * 2;
         // eslint-disable-next-line @convex-dev/explicit-table-ids -- embeddingId is a VectorTableId (union of vectors_128..vectors_4096)
         await ctx.db.delete(chunk.state.embeddingId);
       }
@@ -539,45 +539,8 @@ export async function deleteChunksPageHandler(
   return { isDone: true, nextStartOrder: -1 };
 }
 
-function estimateEmbeddingSize(embedding: Doc<VectorTableName>) {
-  let dataUsedSoFar =
-    embedding.vector.length * 8 +
-    embedding.namespaceId.length +
-    embedding._id.length +
-    8;
-  for (const filter of [
-    embedding.filter0,
-    embedding.filter1,
-    embedding.filter2,
-    embedding.filter3,
-  ]) {
-    if (filter) {
-      dataUsedSoFar += JSON.stringify(convexToJson(filter[1])).length;
-    }
-  }
-  return dataUsedSoFar;
-}
-
-function estimateChunkSize(chunk: Doc<"chunks">) {
-  let dataUsedSoFar = 100; // constant metadata - roughly
-  if (chunk.state.kind === "pending") {
-    dataUsedSoFar += chunk.state.embedding.length * 8;
-    dataUsedSoFar += chunk.state.pendingSearchableText?.length ?? 0;
-  } else if (chunk.state.kind === "replaced") {
-    dataUsedSoFar += chunk.state.vector.length * 8;
-    dataUsedSoFar += chunk.state.pendingSearchableText?.length ?? 0;
-  }
-  return dataUsedSoFar;
-}
 async function estimateContentSize(ctx: QueryCtx, contentId: Id<"content">) {
-  let dataUsedSoFar = 0;
   // TODO: if/when deletions don't count as bandwidth, we can remove this.
   const content = await ctx.db.get("content", contentId);
-  if (content) {
-    dataUsedSoFar += content.text.length;
-    dataUsedSoFar += JSON.stringify(
-      convexToJson(content.metadata ?? {}),
-    ).length;
-  }
-  return dataUsedSoFar;
+  return getConvexSize(content);
 }

--- a/src/component/embeddings/index.test.ts
+++ b/src/component/embeddings/index.test.ts
@@ -55,6 +55,7 @@ describe("embeddings", () => {
 
     // Verify the vector was inserted correctly
     const insertedVector = await t.run(async (ctx) => {
+      // eslint-disable-next-line @convex-dev/explicit-table-ids -- vectorId is a VectorTableId (union of vectors_128..vectors_4096)
       return ctx.db.get(vectorId);
     });
 
@@ -98,6 +99,7 @@ describe("embeddings", () => {
     });
 
     const insertedVector = await t.run(async (ctx) => {
+      // eslint-disable-next-line @convex-dev/explicit-table-ids -- vectorId is a VectorTableId (union of vectors_128..vectors_4096)
       return ctx.db.get(vectorId);
     });
 
@@ -110,6 +112,7 @@ describe("embeddings", () => {
     });
 
     const vectorWithoutImportanceData = await t.run(async (ctx) => {
+      // eslint-disable-next-line @convex-dev/explicit-table-ids -- vectorWithoutImportance is a VectorTableId (union of vectors_128..vectors_4096)
       return ctx.db.get(vectorWithoutImportance);
     });
 
@@ -193,7 +196,9 @@ describe("embeddings", () => {
     });
 
     // Verify filters are in correct fields
+    // eslint-disable-next-line @convex-dev/explicit-table-ids -- vectorId0 is a VectorTableId (union of vectors_128..vectors_4096)
     const vector0 = await t.run(async (ctx) => ctx.db.get(vectorId0));
+    // eslint-disable-next-line @convex-dev/explicit-table-ids -- vectorId2 is a VectorTableId (union of vectors_128..vectors_4096)
     const vector2 = await t.run(async (ctx) => ctx.db.get(vectorId2));
 
     expect(vector0!.filter0).toEqual([namespaceId, "entries"]);
@@ -247,7 +252,9 @@ describe("embeddings", () => {
       });
     });
 
+    // eslint-disable-next-line @convex-dev/explicit-table-ids -- vector1Id is a VectorTableId (union of vectors_128..vectors_4096)
     const vector1 = await t.run(async (ctx) => ctx.db.get(vector1Id));
+    // eslint-disable-next-line @convex-dev/explicit-table-ids -- vector2Id is a VectorTableId (union of vectors_128..vectors_4096)
     const vector2 = await t.run(async (ctx) => ctx.db.get(vector2Id));
 
     // Both have the same filter value but different namespace prefixes
@@ -311,11 +318,13 @@ describe("embeddings", () => {
 
     // All results should be from the correct namespace
     for (const result of results1) {
+      // eslint-disable-next-line @convex-dev/explicit-table-ids -- result._id is a VectorTableId (union of vectors_128..vectors_4096)
       const vector = await t.run(async (ctx) => ctx.db.get(result._id));
       expect(vector!.namespaceId).toBe(namespace1Id);
     }
 
     for (const result of results2) {
+      // eslint-disable-next-line @convex-dev/explicit-table-ids -- result._id is a VectorTableId (union of vectors_128..vectors_4096)
       const vector = await t.run(async (ctx) => ctx.db.get(result._id));
       expect(vector!.namespaceId).toBe(namespace2Id);
     }
@@ -425,6 +434,7 @@ describe("embeddings", () => {
     // Verify the results contain the expected filters
     const vectorIds = orResults.map((r) => r._id);
     const vectors = await t.run(async (ctx) => {
+      // eslint-disable-next-line @convex-dev/explicit-table-ids -- id is a VectorTableId (union of vectors_128..vectors_4096)
       return Promise.all(vectorIds.map((id) => ctx.db.get(id)));
     });
 
@@ -475,6 +485,7 @@ describe("embeddings", () => {
 
     // The first result should be more similar to embedding1 (0.1) than embedding2 (0.2)
     // since searchEmbedding (0.15) is closer to 0.1
+    // eslint-disable-next-line @convex-dev/explicit-table-ids -- results[0]._id is a VectorTableId (union of vectors_128..vectors_4096)
     const firstVector = await t.run(async (ctx) => ctx.db.get(results[0]._id));
     expect(firstVector).toBeDefined();
   });

--- a/src/component/embeddings/index.test.ts
+++ b/src/component/embeddings/index.test.ts
@@ -8,6 +8,7 @@ import { insertEmbedding, searchEmbeddings } from "./index.js";
 import { vectorWithImportanceDimension } from "./importance.js";
 import { action } from "../_generated/server.js";
 import { anyApi, type ApiFromModules } from "convex/server";
+import { getVectorTableName, VectorDimension } from "./tables.js";
 
 export const search = action({
   args: {
@@ -27,6 +28,9 @@ const testApi: ApiFromModules<{
   };
 }>["fns"] = anyApi["embeddings"]["index.test"] as any;
 
+const dimension: VectorDimension = 128;
+const vectorTableName = getVectorTableName(dimension);
+
 describe("embeddings", () => {
   test("insertEmbedding with no filters or importance works", async () => {
     const t = convexTest(schema, modules);
@@ -37,14 +41,14 @@ describe("embeddings", () => {
         namespace: "test-namespace",
         version: 1,
         modelId: "test-model",
-        dimension: 128,
+        dimension,
         filterNames: [],
         status: { kind: "ready" },
       });
     });
 
-    // Create a simple 128-dimension embedding
-    const embedding = Array(128).fill(0.1);
+    // Create a simple embedding
+    const embedding = Array(dimension).fill(0.1);
 
     // Insert embedding without filters or importance
     const vectorId = await t.run(async (ctx) => {
@@ -55,14 +59,13 @@ describe("embeddings", () => {
 
     // Verify the vector was inserted correctly
     const insertedVector = await t.run(async (ctx) => {
-      // eslint-disable-next-line @convex-dev/explicit-table-ids -- vectorId is a VectorTableId (union of vectors_128..vectors_4096)
-      return ctx.db.get(vectorId);
+      return ctx.db.get(vectorTableName, vectorId);
     });
 
     expect(insertedVector).toBeDefined();
     expect(insertedVector!.namespaceId).toBe(namespaceId);
     expect(insertedVector!.vector).toHaveLength(
-      vectorWithImportanceDimension(128),
+      vectorWithImportanceDimension(dimension),
     );
     expect(insertedVector!.filter0).toBeUndefined();
     expect(insertedVector!.filter1).toBeUndefined();
@@ -78,13 +81,13 @@ describe("embeddings", () => {
         namespace: "test-namespace-importance",
         version: 1,
         modelId: "test-model",
-        dimension: 128,
+        dimension,
         filterNames: [],
         status: { kind: "ready" },
       });
     });
 
-    const embedding = Array(128).fill(0.1);
+    const embedding = Array(dimension).fill(0.1);
     const importance = 0.5;
 
     // Insert embedding with importance
@@ -99,12 +102,11 @@ describe("embeddings", () => {
     });
 
     const insertedVector = await t.run(async (ctx) => {
-      // eslint-disable-next-line @convex-dev/explicit-table-ids -- vectorId is a VectorTableId (union of vectors_128..vectors_4096)
-      return ctx.db.get(vectorId);
+      return ctx.db.get(vectorTableName, vectorId);
     });
 
     expect(insertedVector).toBeDefined();
-    expect(insertedVector!.vector).toHaveLength(129);
+    expect(insertedVector!.vector).toHaveLength(dimension + 1);
 
     // The importance should affect the vector - it should not be the same as without importance
     const vectorWithoutImportance = await t.run(async (ctx) => {
@@ -112,8 +114,7 @@ describe("embeddings", () => {
     });
 
     const vectorWithoutImportanceData = await t.run(async (ctx) => {
-      // eslint-disable-next-line @convex-dev/explicit-table-ids -- vectorWithoutImportance is a VectorTableId (union of vectors_128..vectors_4096)
-      return ctx.db.get(vectorWithoutImportance);
+      return ctx.db.get(vectorTableName, vectorWithoutImportance);
     });
 
     // Vectors should be different due to importance scaling
@@ -123,7 +124,7 @@ describe("embeddings", () => {
 
     // The last element should be the weight: sqrt(1 - importance^2)
     const expectedWeight = Math.sqrt(1 - importance ** 2);
-    expect(insertedVector!.vector[128]).toBeCloseTo(expectedWeight, 5);
+    expect(insertedVector!.vector[dimension]).toBeCloseTo(expectedWeight, 5);
   });
 
   test("search for vectors sorted by importance when identical otherwise", async () => {
@@ -134,13 +135,13 @@ describe("embeddings", () => {
         namespace: "importance-sort-test",
         version: 1,
         modelId: "test-model",
-        dimension: 128,
+        dimension,
         filterNames: [],
         status: { kind: "ready" },
       });
     });
 
-    const embedding = Array(128).fill(0.1);
+    const embedding = Array(dimension).fill(0.1);
 
     // Insert same embedding with different importance levels
     await t.run(async (ctx) => {
@@ -173,13 +174,13 @@ describe("embeddings", () => {
         namespace: "filter-test",
         version: 1,
         modelId: "test-model",
-        dimension: 128,
+        dimension,
         filterNames: ["category", "priority", "status", "author"],
         status: { kind: "ready" },
       });
     });
 
-    const embedding = Array(128).fill(0.1);
+    const embedding = Array(dimension).fill(0.1);
 
     // Insert embedding with filter on position 0
     const vectorId0 = await t.run(async (ctx) => {
@@ -196,10 +197,12 @@ describe("embeddings", () => {
     });
 
     // Verify filters are in correct fields
-    // eslint-disable-next-line @convex-dev/explicit-table-ids -- vectorId0 is a VectorTableId (union of vectors_128..vectors_4096)
-    const vector0 = await t.run(async (ctx) => ctx.db.get(vectorId0));
-    // eslint-disable-next-line @convex-dev/explicit-table-ids -- vectorId2 is a VectorTableId (union of vectors_128..vectors_4096)
-    const vector2 = await t.run(async (ctx) => ctx.db.get(vectorId2));
+    const vector0 = await t.run(async (ctx) =>
+      ctx.db.get(vectorTableName, vectorId0),
+    );
+    const vector2 = await t.run(async (ctx) =>
+      ctx.db.get(vectorTableName, vectorId2),
+    );
 
     expect(vector0!.filter0).toEqual([namespaceId, "entries"]);
     expect(vector0!.filter1).toBeUndefined();
@@ -220,7 +223,7 @@ describe("embeddings", () => {
         namespace: "namespace1",
         version: 1,
         modelId: "test-model",
-        dimension: 128,
+        dimension,
         filterNames: ["type"],
         status: { kind: "ready" },
       });
@@ -231,13 +234,13 @@ describe("embeddings", () => {
         namespace: "namespace2",
         version: 1,
         modelId: "test-model",
-        dimension: 128,
+        dimension,
         filterNames: ["type"],
         status: { kind: "ready" },
       });
     });
 
-    const embedding = Array(128).fill(0.1);
+    const embedding = Array(dimension).fill(0.1);
 
     // Insert same filter value in different namespaces
     const vector1Id = await t.run(async (ctx) => {
@@ -252,10 +255,12 @@ describe("embeddings", () => {
       });
     });
 
-    // eslint-disable-next-line @convex-dev/explicit-table-ids -- vector1Id is a VectorTableId (union of vectors_128..vectors_4096)
-    const vector1 = await t.run(async (ctx) => ctx.db.get(vector1Id));
-    // eslint-disable-next-line @convex-dev/explicit-table-ids -- vector2Id is a VectorTableId (union of vectors_128..vectors_4096)
-    const vector2 = await t.run(async (ctx) => ctx.db.get(vector2Id));
+    const vector1 = await t.run(async (ctx) =>
+      ctx.db.get(vectorTableName, vector1Id),
+    );
+    const vector2 = await t.run(async (ctx) =>
+      ctx.db.get(vectorTableName, vector2Id),
+    );
 
     // Both have the same filter value but different namespace prefixes
     expect(vector1!.filter0).toEqual([namespace1Id, "article"]);
@@ -271,7 +276,7 @@ describe("embeddings", () => {
         namespace: "namespace1",
         version: 1,
         modelId: "test-model",
-        dimension: 128,
+        dimension,
         filterNames: [],
         status: { kind: "ready" },
       });
@@ -282,13 +287,13 @@ describe("embeddings", () => {
         namespace: "namespace2",
         version: 1,
         modelId: "test-model",
-        dimension: 128,
+        dimension,
         filterNames: [],
         status: { kind: "ready" },
       });
     });
 
-    const embedding = Array(128).fill(0.1);
+    const embedding = Array(dimension).fill(0.1);
 
     // Insert vectors in both namespaces
     await t.run(async (ctx) => {
@@ -318,14 +323,16 @@ describe("embeddings", () => {
 
     // All results should be from the correct namespace
     for (const result of results1) {
-      // eslint-disable-next-line @convex-dev/explicit-table-ids -- result._id is a VectorTableId (union of vectors_128..vectors_4096)
-      const vector = await t.run(async (ctx) => ctx.db.get(result._id));
+      const vector = await t.run(async (ctx) =>
+        ctx.db.get(vectorTableName, result._id),
+      );
       expect(vector!.namespaceId).toBe(namespace1Id);
     }
 
     for (const result of results2) {
-      // eslint-disable-next-line @convex-dev/explicit-table-ids -- result._id is a VectorTableId (union of vectors_128..vectors_4096)
-      const vector = await t.run(async (ctx) => ctx.db.get(result._id));
+      const vector = await t.run(async (ctx) =>
+        ctx.db.get(vectorTableName, result._id),
+      );
       expect(vector!.namespaceId).toBe(namespace2Id);
     }
   });
@@ -338,13 +345,13 @@ describe("embeddings", () => {
         namespace: "filtered-search",
         version: 1,
         modelId: "test-model",
-        dimension: 128,
+        dimension,
         filterNames: ["category", "status"],
         status: { kind: "ready" },
       });
     });
 
-    const embedding = Array(128).fill(0.1);
+    const embedding = Array(dimension).fill(0.1);
 
     // Insert vectors with different filter combinations
     await t.run(async (ctx) => {
@@ -393,13 +400,13 @@ describe("embeddings", () => {
         namespace: "multi-filter-or",
         version: 1,
         modelId: "test-model",
-        dimension: 128,
+        dimension,
         filterNames: ["category", "priority"],
         status: { kind: "ready" },
       });
     });
 
-    const embedding = Array(128).fill(0.1);
+    const embedding = Array(dimension).fill(0.1);
 
     // Insert vectors with different filter values
     await t.run(async (ctx) => {
@@ -434,8 +441,9 @@ describe("embeddings", () => {
     // Verify the results contain the expected filters
     const vectorIds = orResults.map((r) => r._id);
     const vectors = await t.run(async (ctx) => {
-      // eslint-disable-next-line @convex-dev/explicit-table-ids -- id is a VectorTableId (union of vectors_128..vectors_4096)
-      return Promise.all(vectorIds.map((id) => ctx.db.get(id)));
+      return Promise.all(
+        vectorIds.map((id) => ctx.db.get(vectorTableName, id)),
+      );
     });
 
     const hasArticles = vectors.some((v) => v!.filter0?.[1] === "articles");
@@ -453,17 +461,17 @@ describe("embeddings", () => {
         namespace: "search-test",
         version: 1,
         modelId: "test-model",
-        dimension: 128,
+        dimension,
         filterNames: [],
         status: { kind: "ready" },
       });
     });
 
-    const embedding1 = Array(128).fill(0.1);
+    const embedding1 = Array(dimension).fill(0.1);
     embedding1[0] = 1;
-    const embedding2 = Array(128).fill(0.1);
+    const embedding2 = Array(dimension).fill(0.1);
     embedding2[0] = 0;
-    const searchEmbedding = Array(128).fill(0.1);
+    const searchEmbedding = Array(dimension).fill(0.1);
     searchEmbedding[0] = 0.8; // Closer to embedding1
 
     // Insert two different embeddings
@@ -485,8 +493,9 @@ describe("embeddings", () => {
 
     // The first result should be more similar to embedding1 (0.1) than embedding2 (0.2)
     // since searchEmbedding (0.15) is closer to 0.1
-    // eslint-disable-next-line @convex-dev/explicit-table-ids -- results[0]._id is a VectorTableId (union of vectors_128..vectors_4096)
-    const firstVector = await t.run(async (ctx) => ctx.db.get(results[0]._id));
+    const firstVector = await t.run(async (ctx) =>
+      ctx.db.get(vectorTableName, results[0]._id),
+    );
     expect(firstVector).toBeDefined();
   });
 });

--- a/src/component/entries.test.ts
+++ b/src/component/entries.test.ts
@@ -56,7 +56,7 @@ describe("entries", () => {
 
     // Verify the entry was actually created
     const createdDoc = await t.run(async (ctx) => {
-      return ctx.db.get(result.entryId);
+      return ctx.db.get("entries", result.entryId);
     });
 
     expect(createdDoc).toBeDefined();
@@ -168,7 +168,7 @@ describe("entries", () => {
     });
     expect(firstResult.status).toBe("ready");
     const first = await t.run(async (ctx) => {
-      return ctx.db.get(firstResult.entryId);
+      return ctx.db.get("entries", firstResult.entryId);
     })!;
     expect(first?.version).toBe(0);
     expect(first?.status.kind).toBe("ready");
@@ -187,7 +187,7 @@ describe("entries", () => {
     expect(secondResult.created).toBe(true);
     expect(secondResult.entryId).not.toBe(firstResult.entryId);
     const second = await t.run(async (ctx) => {
-      return ctx.db.get(secondResult.entryId);
+      return ctx.db.get("entries", secondResult.entryId);
     })!;
     expect(second?.version).toBe(1);
     expect(second?.status.kind).toBe("pending");
@@ -195,7 +195,7 @@ describe("entries", () => {
 
     // Verify new version was created
     const newDoc = await t.run(async (ctx) => {
-      return ctx.db.get(secondResult.entryId);
+      return ctx.db.get("entries", secondResult.entryId);
     });
 
     expect(newDoc!.version).toBe(1);
@@ -232,7 +232,7 @@ describe("entries", () => {
 
     // Verify new version was created with correct filter values
     const newDoc = await t.run(async (ctx) => {
-      return ctx.db.get(secondResult.entryId);
+      return ctx.db.get("entries", secondResult.entryId);
     });
 
     expect(newDoc!.version).toBe(1);
@@ -257,7 +257,7 @@ describe("entries", () => {
 
     // Verify the entry was created with pending status
     const createdDoc = await t.run(async (ctx) => {
-      return ctx.db.get(result.entryId);
+      return ctx.db.get("entries", result.entryId);
     });
 
     expect(createdDoc!.status.kind).toBe("pending");
@@ -344,7 +344,7 @@ describe("entries", () => {
 
     // Verify the first entry is now replaced
     const firstDoc = await t.run(async (ctx) => {
-      return ctx.db.get(firstResult.entryId);
+      return ctx.db.get("entries", firstResult.entryId);
     });
     expect(firstDoc!.status.kind).toBe("replaced");
   });
@@ -379,7 +379,7 @@ describe("entries", () => {
 
     // Verify entry and chunks exist before deletion
     const entryBefore = await t.run(async (ctx) => {
-      return ctx.db.get(result.entryId);
+      return ctx.db.get("entries", result.entryId);
     });
     expect(entryBefore).toBeDefined();
 
@@ -402,7 +402,7 @@ describe("entries", () => {
 
     // Verify entry is deleted
     const entryAfter = await t.run(async (ctx) => {
-      return ctx.db.get(result.entryId);
+      return ctx.db.get("entries", result.entryId);
     });
     expect(entryAfter).toBeNull();
 
@@ -446,7 +446,7 @@ describe("entries", () => {
 
     // Verify entry and chunks exist before deletion
     const entryBefore = await t.run(async (ctx) => {
-      return ctx.db.get(result.entryId);
+      return ctx.db.get("entries", result.entryId);
     });
     expect(entryBefore).toBeDefined();
 
@@ -465,7 +465,7 @@ describe("entries", () => {
 
     // Verify entry is deleted
     const entryAfter = await t.run(async (ctx) => {
-      return ctx.db.get(result.entryId);
+      return ctx.db.get("entries", result.entryId);
     });
     expect(entryAfter).toBeNull();
 

--- a/src/component/entries.test.ts
+++ b/src/component/entries.test.ts
@@ -1,4 +1,5 @@
 /// <reference types="vite/client" />
+/* eslint-disable @convex-dev/no-filter-in-query */
 
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { type TestConvex } from "convex-test";

--- a/src/component/entries.ts
+++ b/src/component/entries.ts
@@ -69,7 +69,7 @@ export const addAsync = mutation({
   }),
   handler: async (ctx, args) => {
     const { namespaceId, key } = args.entry;
-    const namespace = await ctx.db.get(namespaceId);
+    const namespace = await ctx.db.get("namespaces", namespaceId);
     assert(namespace, `Namespace ${namespaceId} not found`);
     // iterate through the latest versions of the entry
     const existing = await findExistingEntry(ctx, namespaceId, key);
@@ -134,7 +134,7 @@ export const addAsyncOnComplete = internalMutation({
   returns: v.null(),
   handler: async (ctx, args) => {
     const entryId = args.context;
-    const entry = await ctx.db.get(args.context);
+    const entry = await ctx.db.get("entries", args.context);
     if (!entry) {
       console.error(
         `Entry ${args.context} not found when trying to complete chunker for async add`,
@@ -145,7 +145,7 @@ export const addAsyncOnComplete = internalMutation({
       await promoteToReadyHandler(ctx, { entryId });
     } else {
       // await deleteAsyncHandler(ctx, { entryId, startOrder: 0 });
-      const namespace = await ctx.db.get(entry.namespaceId);
+      const namespace = await ctx.db.get("namespaces", entry.namespaceId);
       assert(namespace, `Namespace ${entry.namespaceId} not found`);
       if (entry.status.kind === "pending" && entry.status.onComplete) {
         await runOnComplete(
@@ -207,7 +207,7 @@ export const add = mutation({
   }),
   handler: async (ctx, args) => {
     const { namespaceId, key } = args.entry;
-    const namespace = await ctx.db.get(namespaceId);
+    const namespace = await ctx.db.get("namespaces", namespaceId);
     assert(namespace, `Namespace ${namespaceId} not found`);
     // iterate through the latest versions of the entry
     const existing = await findExistingEntry(ctx, namespaceId, key);
@@ -327,7 +327,7 @@ export const get = query({
   args: { entryId: v.id("entries") },
   returns: v.union(vEntry, v.null()),
   handler: async (ctx, args) => {
-    const entry = await ctx.db.get(args.entryId);
+    const entry = await ctx.db.get("entries", args.entryId);
     if (!entry) {
       return null;
     }
@@ -409,9 +409,9 @@ async function promoteToReadyHandler(
   ctx: MutationCtx,
   args: { entryId: Id<"entries"> },
 ) {
-  const entry = await ctx.db.get(args.entryId);
+  const entry = await ctx.db.get("entries", args.entryId);
   assert(entry, `Entry ${args.entryId} not found`);
-  const namespace = await ctx.db.get(entry.namespaceId);
+  const namespace = await ctx.db.get("namespaces", entry.namespaceId);
   assert(namespace, `Namespace for ${entry.namespaceId} not found`);
   if (entry.status.kind === "ready") {
     console.debug(`Entry ${args.entryId} is already ready, skipping...`);
@@ -427,13 +427,13 @@ async function promoteToReadyHandler(
   // so there are never two "ready" entries.
   if (previousEntry) {
     previousEntry.status = { kind: "replaced", replacedAt: Date.now() };
-    await ctx.db.replace(previousEntry._id, previousEntry);
+    await ctx.db.replace("entries", previousEntry._id, previousEntry);
   }
   const previousStatus = entry.status;
   entry.status = { kind: "ready" };
   // Only then mark the current entry as ready,
   // so there are never two "ready" entries.
-  await ctx.db.replace(args.entryId, entry);
+  await ctx.db.replace("entries", args.entryId, entry);
   // Then run the onComplete function where it can observe itself as "ready".
   if (previousStatus.kind === "pending" && previousStatus.onComplete) {
     await runOnComplete(
@@ -461,7 +461,7 @@ async function promoteToReadyHandler(
       previousPendingEntries.map(async (entry) => {
         const previousStatus = entry.status;
         entry.status = { kind: "replaced", replacedAt: Date.now() };
-        await ctx.db.replace(entry._id, entry);
+        await ctx.db.replace("entries", entry._id, entry);
         if (previousStatus.kind === "pending" && previousStatus.onComplete) {
           await runOnComplete(
             ctx,
@@ -493,13 +493,13 @@ async function deleteAsyncHandler(
   args: { entryId: Id<"entries">; startOrder: number },
 ) {
   const { entryId, startOrder } = args;
-  const entry = await ctx.db.get(entryId);
+  const entry = await ctx.db.get("entries", entryId);
   if (!entry) {
     throw new Error(`Entry ${entryId} not found`);
   }
   const status = await deleteChunksPageHandler(ctx, { entryId, startOrder });
   if (status.isDone) {
-    await ctx.db.delete(entryId);
+    await ctx.db.delete("entries", entryId);
   } else {
     await workpool.enqueueMutation(ctx, api.entries.deleteAsync, {
       entryId,
@@ -533,7 +533,7 @@ export const _del = internalMutation({
   args: { entryId: v.id("entries") },
   returns: v.null(),
   handler: async (ctx, args) => {
-    await ctx.db.delete(args.entryId);
+    await ctx.db.delete("entries", args.entryId);
   },
 });
 

--- a/src/component/namespaces.test.ts
+++ b/src/component/namespaces.test.ts
@@ -90,7 +90,7 @@ describe("namespaces", () => {
 
     // Verify namespace is deleted
     const namespaceAfter = await t.run(async (ctx) => {
-      return ctx.db.get(namespaceId);
+      return ctx.db.get("namespaces", namespaceId);
     });
     expect(namespaceAfter).toBeNull();
   });

--- a/src/component/namespaces.test.ts
+++ b/src/component/namespaces.test.ts
@@ -1,4 +1,5 @@
 /// <reference types="vite/client" />
+/* eslint-disable @convex-dev/no-filter-in-query */
 
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { type TestConvex } from "convex-test";

--- a/src/component/namespaces.ts
+++ b/src/component/namespaces.ts
@@ -153,7 +153,7 @@ async function promoteToReadyHandler(
   ctx: MutationCtx,
   args: { namespaceId: Id<"namespaces"> },
 ) {
-  const namespace = await ctx.db.get(args.namespaceId);
+  const namespace = await ctx.db.get("namespaces", args.namespaceId);
   assert(namespace, `Namespace ${args.namespaceId} not found`);
   if (namespace.status.kind === "ready") {
     console.debug(
@@ -177,13 +177,13 @@ async function promoteToReadyHandler(
     // First mark the previous namespace as replaced,
     // so there are never two "ready" namespaces.
     previousNamespace.status = { kind: "replaced", replacedAt: Date.now() };
-    await ctx.db.replace(previousNamespace._id, previousNamespace);
+    await ctx.db.replace("namespaces", previousNamespace._id, previousNamespace);
   }
   // Only then mark the current namespace as ready,
   // so there are never two "ready" namespaces.
   const previousStatus = namespace.status;
   namespace.status = { kind: "ready" };
-  await ctx.db.replace(args.namespaceId, namespace);
+  await ctx.db.replace("namespaces", args.namespaceId, namespace);
   // Then run the onComplete function where it can observe itself as "ready".
   if (previousStatus.kind === "pending" && previousStatus.onComplete) {
     await runOnComplete(
@@ -208,7 +208,7 @@ async function promoteToReadyHandler(
     previousPendingNamespaces.map(async (namespace) => {
       const previousStatus = namespace.status;
       namespace.status = { kind: "replaced", replacedAt: Date.now() };
-      await ctx.db.replace(namespace._id, namespace);
+      await ctx.db.replace("namespaces", namespace._id, namespace);
       if (previousStatus.kind === "pending" && previousStatus.onComplete) {
         await runOnComplete(ctx, previousStatus.onComplete, namespace, null);
       }
@@ -277,7 +277,7 @@ async function deleteHandler(
   ctx: MutationCtx,
   args: { namespaceId: Id<"namespaces"> },
 ) {
-  const namespace = await ctx.db.get(args.namespaceId);
+  const namespace = await ctx.db.get("namespaces", args.namespaceId);
   assert(namespace, `Namespace ${args.namespaceId} not found`);
   const anyEntry = await ctx.db
     .query("entries")
@@ -292,7 +292,7 @@ async function deleteHandler(
         `Entry: ${anyEntry.key} id ${anyEntry._id} (${anyEntry.status.kind})`,
     );
   }
-  await ctx.db.delete(args.namespaceId);
+  await ctx.db.delete("namespaces", args.namespaceId);
   return { deletedNamespace: publicNamespace(namespace) };
 }
 

--- a/src/component/search.ts
+++ b/src/component/search.ts
@@ -317,7 +317,7 @@ export const textAndRanges = internalQuery({
 
     // 4. Build ranges from merged chunk IDs.
     const chunks = await Promise.all(
-      mergedChunkIds.map((id) => ctx.db.get(id)),
+      mergedChunkIds.map((id) => ctx.db.get("chunks", id)),
     );
     const { ranges, entries } = await buildRanges(
       ctx,


### PR DESCRIPTION
## Summary
- Install and configure `@convex-dev/eslint-plugin`
- Auto-fix `explicit-table-ids` violations (adds table name as first arg to `db.get`/`db.patch`/`db.delete`/`db.replace`)
- Add eslint-disable annotations where table names are genuinely dynamic

🤖 Generated with [Claude Code](https://claude.com/claude-code)