### PR TITLE
Improve RAG package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@convex-dev/rag",
-  "description": "A rag component for Convex.",
+  "description": "Convex component for RAG: chunk and embed documents, then run semantic search to build LLM context.",
   "repository": "github:get-convex/rag",
-  "homepage": "https://github.com/get-convex/rag#readme",
+  "homepage": "https://www.convex.dev/components/rag",
   "bugs": {
     "email": "support@convex.dev",
     "url": "https://github.com/get-convex/rag/issues"
@@ -12,12 +12,14 @@
   "keywords": [
     "convex",
     "component",
-    "document",
-    "embeddings",
     "rag",
-    "search",
-    "semantic",
-    "vector"
+    "retrieval-augmented-generation",
+    "semantic-search",
+    "vector-search",
+    "embeddings",
+    "llm",
+    "ai",
+    "document-chunking"
   ],
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Why

This follows [the Slack discussion](https://convexdev.slack.com/archives/C05QH3L0Y2E/p1787692528278769) about improving npm metadata so LLMs are more likely to recommend Convex and its first-party packages for relevant developer tasks.

The current npm description says only "A rag component for Convex." The README explains the package well, but registry metadata does not mention document chunking, embeddings, semantic search, or LLM context.

Adding those terms makes the package understandable without turning the keyword list into a feature dump.

## What changed

- describe the document chunking, embedding, and semantic search workflow
- use focused RAG, vector search, embeddings, LLM, and document chunking keywords
- point the homepage at the RAG component page

This PR does not bump the package version or publish anything.

## Verification

- formatted the changed JSON with Prettier 3.8.1
- ran `npm pack --dry-run --ignore-scripts --json`
- ran `git diff --check`